### PR TITLE
Mac conda

### DIFF
--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -36,10 +36,17 @@ jobs:
       - name: Bash
         shell: bash -el {0}
         run: |
-          conda install -c r bioconductor-rhdf5lib
+          conda install -c r r-biocmanager bioconductor-rhdf5lib
 
       - name: R
         shell: Rscript {0}
         run: |
-          library(Rhdf5lib)
+          .libPaths()
+          installed.packages()[,1:2]
           sessionInfo()
+
+      - name: R
+        shell: Rscript {0}
+        run: |
+          BiocManager::install('Rhdf5lib', lib = tempdir())
+          

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -36,9 +36,8 @@ jobs:
       - name: Bash
         shell: bash -el {0}
         run: |
-          mamba install -c r 
-          mamba install bioconductor-rhdf5lib
-          
+          conda install -c r bioconductor-rhdf5lib
+
       - name: R
         shell: Rscript {0}
         run: |

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -26,49 +26,16 @@ jobs:
           activate-environment: foo
           architecture: arm64
       
-      - name: System details
-        shell: bash -el {0}
-        run: |
-          echo ${host_alias}
-          echo ${build_alias}
-          (uname -m)
-          (uname -r)
-          (uname -s)
-          (uname -v)
-          
-      - name: Testing scripts
-        shell: bash -el {0}
-        run: |
-          wget -O config.sub https://git.savannah.gnu.org/cgit/config.git/plain/config.sub 
-          wget -O config.guess https://git.savannah.gnu.org/cgit/config.git/plain/config.guess 
-          bash ./config.guess
-          bash ./config.sub $(bash ./config.guess)
-        working-directory: ${{ runner.temp }}  
-          
       - name: Bash
         shell: bash -el {0}
         run: |
           conda install -c r r-biocmanager r-remotes
           
-      - name: Testing scripts
-        shell: bash -el {0}
-        run: |
-          bash ./config.guess
-          bash ./config.sub $(bash ./config.guess)
-        working-directory: ${{ runner.temp }}  
-
       - name: Install Rhdf5lib from source
         shell: bash -el {0}
         run: |
           mkdir ${{ runner.temp }}/R-lib
-          R CMD config --all
-          R -e 'BiocManager::install("grimbough/Rhdf5lib", lib = tempdir(), ref="mac-conda")'
-          R CMD INSTALL --library=${{ runner.temp }}/R-lib Rhdf5lib
-          
-      - name: Install Rhdf5lib from source
-        shell: bash -el {0}
-        run: |
-          unset host_alias
-          unset build_alias
-          R -e 'BiocManager::install("Rhdf5lib", lib = tempdir())'
+          R CMD INSTALL --library=${{ runner.temp }}/R-lib ${{ github.workspace }}/Rhdf5lib
+        working-directory: ${{ runner.temp }} 
+        
           

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -33,10 +33,10 @@ jobs:
       - name: R
         shell: bash -el {0}
         run: |
-          R -e .libPaths() -e installed.packages()[,1:2] -e sessionInfo()
+          R -e '.libPaths()' -e 'installed.packages()[,1:2]' -e 'sessionInfo()'
 
       - name: R
         shell: bash -el {0}
         run: |
-          R -e BiocManager::install('Rhdf5lib', lib = tempdir())
+          R -e 'BiocManager::install("Rhdf5lib", lib = tempdir())'
           

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -1,0 +1,41 @@
+on:
+  workflow_dispatch:
+
+name: OSX and Conda
+
+env:
+  GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+  R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+
+jobs:
+  test-pkg:
+    runs-on: macOS-latest
+    name: testing conda
+
+    steps:
+
+      - uses: actions/checkout@v4
+          
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          use-mamba: true
+          miniconda-version: "latest"
+          activate-environment: foo
+      
+      - name: Bash
+        shell: bash -el {0}
+        run: |
+          mamba info
+          mamba list
+
+      - name: Bash
+        shell: bash -el {0}
+        run: |
+          mamba install -c r 
+          mamba install bioconda::bioconductor-rhdf5lib
+          
+      - name: R
+        shell: Rscript {0}
+        run: |
+          library(Rhdf5lib)
+          sessionInfo()

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash -el {0}
         run: |
           mkdir ${{ runner.temp }}/R-lib
-          R CMD INSTALL --library=${{ runner.temp }}/R-lib ${{ github.workspace }}/Rhdf5lib
+          R CMD INSTALL --library=${{ runner.temp }}/R-lib ${{ github.workspace }}
         working-directory: ${{ runner.temp }} 
         
           

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash -el {0}
         run: |
           uname -a
-          conda install -c r r-biocmanager bioconductor-rhdf5lib
+          conda install -c r r-biocmanager
           echo $PATH
           conda list
 
@@ -38,7 +38,6 @@ jobs:
         shell: bash -el {0}
         run: |
           R -e '.libPaths()' -e 'installed.packages()[,1:2]' -e 'sessionInfo()'
-          R -e 'library(Rhdf5lib)'
 
       - name: Install Rhdf5lib from source
         shell: bash -el {0}

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -45,6 +45,13 @@ jobs:
         shell: bash -el {0}
         run: |
           conda install -c r r-biocmanager
+          
+      - name: Testing scripts
+        shell: bash -el {0}
+        run: |
+          bash ./config.guess
+          bash ./config.sub $(bash ./config.guess)
+        working-directory: ${{ runner.temp }}  
 
       - name: Install Rhdf5lib from source
         shell: bash -el {0}

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Bash
         shell: bash -el {0}
         run: |
-          conda install -c r r-biocmanager
+          conda install -c r r-biocmanager r-remotes
           
       - name: Testing scripts
         shell: bash -el {0}
@@ -60,8 +60,10 @@ jobs:
       - name: Install Rhdf5lib from source
         shell: bash -el {0}
         run: |
+          mkdir ${{ runner.temp }}/R-lib
           R CMD config --all
           R -e 'BiocManager::install("grimbough/Rhdf5lib", lib = tempdir(), ref="mac-conda")'
+          R CMD INSTALL --library=${{ runner.temp }}/R-lib Rhdf5lib
           
       - name: Install Rhdf5lib from source
         shell: bash -el {0}

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -32,6 +32,15 @@ jobs:
           echo ${host_alias}
           echo ${build_alias}
           
+      - name: Testing scripts
+        shell: bash -el {0}
+        run: |
+          wget -O config.sub https://git.savannah.gnu.org/cgit/config.git/plain/config.sub 
+          wget -O config.guess https://git.savannah.gnu.org/cgit/config.git/plain/config.guess 
+          bash ./config.guess
+          bash ./config.sub $(bash ./config.guess)
+        working-directory: ${{ runner.temp }}  
+          
       - name: Bash
         shell: bash -el {0}
         run: |

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -1,4 +1,5 @@
 on:
+  push:
   workflow_dispatch:
 
 name: OSX and Conda

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -37,7 +37,7 @@ jobs:
         shell: bash -el {0}
         run: |
           R -e '.libPaths()' -e 'installed.packages()[,1:2]' -e 'sessionInfo()'
-          library(Rhdf5lib)
+          R -e 'library(Rhdf5lib)'
 
       - name: Install Rhdf5lib from source
         shell: bash -el {0}

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   test-pkg:
-    runs-on: macOS-latest
+    runs-on: macOS-14
     name: testing conda
 
     steps:
@@ -28,6 +28,7 @@ jobs:
       - name: Bash
         shell: bash -el {0}
         run: |
+          uname -a
           conda install -c r r-biocmanager bioconductor-rhdf5lib
 
       - name: R

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -26,6 +26,12 @@ jobs:
           activate-environment: foo
           architecture: arm64
       
+      - name: System details
+        shell: bash -el {0}
+        run: |
+          echo ${host_alias}
+          echo ${build_alias}
+          
       - name: Bash
         shell: bash -el {0}
         run: |

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -29,18 +29,17 @@ jobs:
       - name: Bash
         shell: bash -el {0}
         run: |
-          uname -a
           conda install -c r r-biocmanager
-          echo $PATH
-          conda list
-
-      - name: R
-        shell: bash -el {0}
-        run: |
-          R -e '.libPaths()' -e 'installed.packages()[,1:2]' -e 'sessionInfo()'
 
       - name: Install Rhdf5lib from source
         shell: bash -el {0}
         run: |
+          R -e 'BiocManager::install("Rhdf5lib", lib = tempdir())'
+          
+      - name: Install Rhdf5lib from source
+        shell: bash -el {0}
+        run: |
+          unset host_alias
+          unset build_alias
           R -e 'BiocManager::install("Rhdf5lib", lib = tempdir())'
           

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           use-mamba: true
           miniconda-version: "latest"
+          channels: conda-forge,defaults,bioconda
+          channel-priority: true
           activate-environment: foo
       
       - name: Bash
@@ -33,7 +35,7 @@ jobs:
         shell: bash -el {0}
         run: |
           mamba install -c r 
-          mamba install bioconda::bioconductor-rhdf5lib
+          mamba install bioconductor-rhdf5lib
           
       - name: R
         shell: Rscript {0}

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -24,6 +24,7 @@ jobs:
           channels: conda-forge,defaults,bioconda
           channel-priority: true
           activate-environment: foo
+          architecture: arm64
       
       - name: Bash
         shell: bash -el {0}

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -29,13 +29,16 @@ jobs:
         shell: bash -el {0}
         run: |
           conda install -c r r-biocmanager bioconductor-rhdf5lib
+          echo $PATH
+          conda list
 
       - name: R
         shell: bash -el {0}
         run: |
           R -e '.libPaths()' -e 'installed.packages()[,1:2]' -e 'sessionInfo()'
+          library(Rhdf5lib)
 
-      - name: R
+      - name: Install Rhdf5lib from source
         shell: bash -el {0}
         run: |
           R -e 'BiocManager::install("Rhdf5lib", lib = tempdir())'

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -25,28 +25,18 @@ jobs:
           channel-priority: true
           activate-environment: foo
       
-      - shell: bash -el {0}
-        run: |
-          conda info
-          conda list
-          conda config --show-sources
-          conda config --show
-          printenv | sort
-
       - name: Bash
         shell: bash -el {0}
         run: |
           conda install -c r r-biocmanager bioconductor-rhdf5lib
 
       - name: R
-        shell: Rscript {0}
+        shell: bash -el {0}
         run: |
-          .libPaths()
-          installed.packages()[,1:2]
-          sessionInfo()
+          R -e .libPaths() -e installed.packages()[,1:2] -e sessionInfo()
 
       - name: R
-        shell: Rscript {0}
+        shell: bash -el {0}
         run: |
-          BiocManager::install('Rhdf5lib', lib = tempdir())
+          R -e BiocManager::install('Rhdf5lib', lib = tempdir())
           

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -25,11 +25,13 @@ jobs:
           channel-priority: true
           activate-environment: foo
       
-      - name: Bash
-        shell: bash -el {0}
+      - shell: bash -el {0}
         run: |
-          mamba info
-          mamba list
+          conda info
+          conda list
+          conda config --show-sources
+          conda config --show
+          printenv | sort
 
       - name: Bash
         shell: bash -el {0}

--- a/.github/workflows/mac-conda.yml
+++ b/.github/workflows/mac-conda.yml
@@ -31,6 +31,10 @@ jobs:
         run: |
           echo ${host_alias}
           echo ${build_alias}
+          (uname -m)
+          (uname -r)
+          (uname -s)
+          (uname -v)
           
       - name: Testing scripts
         shell: bash -el {0}
@@ -56,7 +60,8 @@ jobs:
       - name: Install Rhdf5lib from source
         shell: bash -el {0}
         run: |
-          R -e 'BiocManager::install("Rhdf5lib", lib = tempdir())'
+          R CMD config --all
+          R -e 'BiocManager::install("grimbough/Rhdf5lib", lib = tempdir(), ref="mac-conda")'
           
       - name: Install Rhdf5lib from source
         shell: bash -el {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 on:
   push:
-    braches:
-      - !mac-conda
+    branches-ignore:
+      - mac-conda
   pull_request:
     branches:
       - master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    braches:
+      - !mac-conda
   pull_request:
     branches:
       - master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
       - mac-conda
   pull_request:
     branches:
-      - master
+      - devel
 
 name: R-CMD-check
 
@@ -21,10 +21,11 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { os: windows-2022, bioc-version: 'devel'}
-        - { os: macOS-latest, bioc-version: 'devel'}
-        - { os: ubuntu-20.04, bioc-version: 'devel', system-libs: 'libcurl4-gnutls-dev libaec-dev'}
-        - { os: ubuntu-22.04, bioc-version: 'devel', system-libs: 'libcurl4-openssl-dev'}
+        - { os: windows-2022, bioc-version: 'devel', Ncpus: 4}
+        - { os: macOS-13,     bioc-version: 'devel', Ncpus: 4}
+        - { os: macOS-14,     bioc-version: 'devel', Ncpus: 3}
+        - { os: ubuntu-20.04, bioc-version: 'devel', Ncpus: 4, system-libs: 'libcurl4-gnutls-dev libaec-dev'}
+        - { os: ubuntu-22.04, bioc-version: 'devel', Ncpus: 4, system-libs: 'libcurl4-openssl-dev'}
 
     steps:
       - name: Configure git
@@ -43,21 +44,15 @@ jobs:
           install.libs("openssl")
         shell: Rscript {0}
         
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
           
       - name: Setup R and Bioconductor
         uses: grimbough/bioc-actions/setup-bioc@v1
         with:
           bioc-version: ${{ matrix.config.bioc-version }}
           bioc-mirror: https://ftp.gwdg.de/pub/misc/bioconductor
+          Ncpus: ${{ matrix.config.Ncpus }}
           
-      # - name: Create Makevars
-      #   if: ${{ matrix.config.os == 'macOS-latest' }}
-      #   run: |
-      #     mkdir $HOME/.R
-      #     echo 'LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"' > $HOME/.R/Makevars
-      #     echo 'CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"' >> $HOME/.R/Makevars
-
       - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Install dependencies
@@ -84,14 +79,14 @@ jobs:
         
       - name: Upload check results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.config.os }}-results
           path: ${{ steps.build-install-check.outputs.check-dir }}
           
       - name: Upload check results
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.config.os }}-${{ matrix.config.r }}-hdf5_config.log
           path: check/*.Rcheck/00_pkg_src/Rhdf5lib/src/hdf5/config.log

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rhdf5lib
 Type: Package
 Title: hdf5 library as an R package
-Version: 1.25.1
+Version: 1.25.2
 Authors@R: c(
             person(
               "Mike", "Smith", 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,15 @@
+Version 1.26
+=============
+
+Bug fixes:
+
+  o Updated parts of the bundled HDF5 configure scripts (config.guess &
+  config.sub) which were very old and didn't recognise Apple arm64 systems
+  when running R installed via conda. (Thanks to @eyalbenda for reporting, 
+  https://github.com/grimbough/Rhdf5lib/issues/54)  Backported to 
+  Rhdf5lib version 1.24.2
+
+  
 Version 1.24
 =============
 

--- a/configure
+++ b/configure
@@ -3997,7 +3997,7 @@ else $as_nop
   :
 fi
 
-elif echo $CC_BASENAME | grep -q clang; then
+elif echo $CC_BASENAME | grep -q 'clang\|gcc'; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -w" >&5
 printf %s "checking whether C compiler accepts -w... " >&6; }
 if test ${ax_cv_check_cflags___w+y}

--- a/configure
+++ b/configure
@@ -3997,6 +3997,45 @@ else $as_nop
   :
 fi
 
+elif echo $CC_BASENAME | grep -q clang; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -w" >&5
+printf %s "checking whether C compiler accepts -w... " >&6; }
+if test ${ax_cv_check_cflags___w+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS  -w"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ax_cv_check_cflags___w=yes
+else $as_nop
+  ax_cv_check_cflags___w=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___w" >&5
+printf "%s\n" "$ax_cv_check_cflags___w" >&6; }
+if test "x$ax_cv_check_cflags___w" = xyes
+then :
+  CFLAGS="$CFLAGS -w"; CXXFLAGS="-w $CXXFLAGS"
+else $as_nop
+  :
+fi
+
 fi
 
 ###########################

--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ echo "COMPILER = $CC_BASENAME"
 
 if test "X$CC_BASENAME" = "Xgcc" -o "X$CC_BASENAME" = "Xclang"; then
   AX_CHECK_COMPILE_FLAG([-w], [CFLAGS="$CFLAGS -w"; CXXFLAGS="-w $CXXFLAGS"])
-elif echo $CC_BASENAME | grep -q clang; then
+elif echo $CC_BASENAME | grep -q 'clang\|gcc'; then
   AX_CHECK_COMPILE_FLAG([-w], [CFLAGS="$CFLAGS -w"; CXXFLAGS="-w $CXXFLAGS"])
 fi
   

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,8 @@ echo "COMPILER = $CC_BASENAME"
 
 if test "X$CC_BASENAME" = "Xgcc" -o "X$CC_BASENAME" = "Xclang"; then
   AX_CHECK_COMPILE_FLAG([-w], [CFLAGS="$CFLAGS -w"; CXXFLAGS="-w $CXXFLAGS"])
+elif echo $CC_BASENAME | grep -q clang; then
+  AX_CHECK_COMPILE_FLAG([-w], [CFLAGS="$CFLAGS -w"; CXXFLAGS="-w $CXXFLAGS"])
 fi
   
 ###########################


### PR DESCRIPTION
Updated parts of the bundled HDF5 configure scripts (config.guess &  config.sub) which were very old and didn't recognise Apple arm64 systems  when running R installed via conda. (Thanks to @eyalbenda for reporting. Fixes #54.