### PR TITLE
Added more explicit mention of PKG_CXX_LIBS

### DIFF
--- a/vignettes/Rhdf5lib.Rmd
+++ b/vignettes/Rhdf5lib.Rmd
@@ -33,6 +33,12 @@ Add the following lines to both `src/Makevars` and `src/Makevars.win`
         'Rhdf5lib::pkgconfig("PKG_C_LIBS")') 
     PKG_LIBS=$(RHDF5_LIBS)
 
+Alternatively if using the C++ interface, please add the following lines instead:
+
+    RHDF5_LIBS=$(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript" -e \ 
+        'Rhdf5lib::pkgconfig("PKG_CXX_LIBS")') 
+    PKG_LIBS=$(RHDF5_LIBS)
+
 The statement for each platform modifies the `$PKG_LIBS` variable. If your package needs to add additional information to the `$PKG_LIBS` variable, do so by adding to the `PKG_LIBS=$(RHDF5_LIBS)` line, e.g.,
 
     PKG_LIBS=$(RHDF5_LIBS) -L/path/to/foolib -lfoo


### PR DESCRIPTION
Sorry for this rather stupid pull request, I recently debugged an issue for a colleague whose package would not build successfully due to missing symbols. It eventually turned out he was using `PKG_C_LIBS` instead of `PKG_CXX_LIBS` while including the `H5Cpp.h` header, thus failing to include the necessary `libhdf5_cpp.a`.

The purpose of this pull request is to make the option of `PKG_CXX_LIBS` more prominent, so that lazy readers like myself are more likely to catch it in the documentation. I think there are many like me that simply look at the code-formatted blocks and copy paste what we think we need without fully reading the rest of the text. These commands are also very arcane given they use bash, environment variables and relate to the C/C++ build system which not many R programmers are proficient with.

My preference would actually be to put `PKG_CXX_LIBS` first, as I would think most R developers would be using Rcpp to access lower level code. Therefore C++ is likely to be more relevant to most users.

Symbol issues in C/C++ compilation are just very difficult to debug, and make particularly so when R is in charge of the building commands. I would hope this pull request can help at least one other user avoid the pain I had to go through.